### PR TITLE
Fixed typo in extension name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Pass ``sphinxcontrib-openapi`` to ``extensions`` list in  Sphinx's ``conf.py``
 
    extensions = [
       ...
-      'sphinxcontrib-openapi',
+      'sphinxcontrib.openapi',
    ]
 
 and feel free to use the ``openapi`` directive to render OpenAPI specs


### PR DESCRIPTION
Fixed the typo in the extensions block, this resolves the following error:
~~~
Could not import extension sphinxcontrib-openapi (exception: No module named sphinxcontrib-openapi)
make: *** [html] Error 1
~~~